### PR TITLE
Fixed allocating buffers above 2GB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ Retrieve the platform info as above for the specific platform selected using `co
 Create an OpenCL program using the `context.createProgram()` method of the context object. This returns a promise that resolves to an OpenCL compiled kernel for an OpenCL _program_ as a program object.
 
 ```Javascript
+await context.initialise();
+```
+
+After creating the context, initialize the context.
+
+```Javascript
 const progPromise = context.createProgram(kernel);
 progPromise.then(program => ..., console.error);
 ```

--- a/src/noden_buffer.cc
+++ b/src/noden_buffer.cc
@@ -330,8 +330,8 @@ napi_value createBuffer(napi_env env, napi_callback_info info) {
     delete c;
     return nullptr;
   }
-  int32_t paramSize;
-  status = napi_get_value_int32(env, args[0], &paramSize);
+  int64_t paramSize;
+  status = napi_get_value_int64(env, args[0], &paramSize);
   CHECK_STATUS;
   if (paramSize < 0) {
     status = napi_throw_error(env, nullptr, "Size of the buffer cannot be negative.");


### PR DESCRIPTION
Although the maximum length for buffer is 4GB
check buffer.constants.MAX_LENGTH
Added hint on initializing the context after creating the context.

Thanks
Karthick